### PR TITLE
Event dispatcher improvement

### DIFF
--- a/src/EventDispatcher/SimpleEventDispatcher.php
+++ b/src/EventDispatcher/SimpleEventDispatcher.php
@@ -57,13 +57,14 @@ final class SimpleEventDispatcher implements EventDispatcherInterface
         return $this->walkBool(static fn(object $event): bool => $event instanceof $class);
     }
 
-    private function walkBool(Closure $closure)
+    private function walkBool(Closure $closure): bool
     {
         foreach ($this->events as $event) {
             if ($closure($event)) {
                 return true;
             }
         }
+
         return false;
     }
 

--- a/src/EventDispatcher/SimpleEventDispatcher.php
+++ b/src/EventDispatcher/SimpleEventDispatcher.php
@@ -16,7 +16,7 @@ final class SimpleEventDispatcher implements EventDispatcherInterface
     private array $events = [];
 
     /**
-     * @param callable[] ...$listeners Callables that will handle events.
+     * @param callable[][] ...$listeners Callables that will handle events.
      */
     public function __construct(array $listeners)
     {

--- a/tests/EventDispatcher/SimpleEventDispatcherTest.php
+++ b/tests/EventDispatcher/SimpleEventDispatcherTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Yiisoft\Test\Support\Tests\EventDispatcher;
 
-use Closure;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
-use RuntimeException;
-use Yiisoft\Test\Support\EventDispatcher\SimpleEventDispatcher;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Throwable;
+use Yiisoft\Test\Support\EventDispatcher\SimpleEventDispatcher;
 use Yiisoft\Test\Support\Tests\EventDispatcher\Stub\StoppableEvent;
 
 class SimpleEventDispatcherTest extends TestCase
@@ -21,12 +21,16 @@ class SimpleEventDispatcherTest extends TestCase
         $listener1 = false;
         $listener2 = false;
         $dispatcher = $this->prepareDispatcher(
-            static function (object $param) use (&$listener1, $event) {
-                $listener1 = $param === $event;
-            },
-            static function (object $param) use (&$listener2, $event) {
-                $listener2 = $param === $event;
-            }
+            [
+                DateTime::class => [
+                    static function (object $param) use (&$listener1, $event) {
+                        $listener1 = $param === $event;
+                    },
+                    static function (object $param) use (&$listener2, $event) {
+                        $listener2 = $param === $event;
+                    },
+                ],
+            ]
         );
 
         $dispatcher->dispatch($event);
@@ -41,19 +45,23 @@ class SimpleEventDispatcherTest extends TestCase
         $listener1 = false;
         $listener2 = false;
         $dispatcher = $this->prepareDispatcher(
-            static function (object $param) use (&$listener1, $event) {
-                $listener1 = $param === $event;
-                throw new RuntimeException();
-            },
-            static function (object $param) use (&$listener2, $event) {
-                $listener2 = $param === $event;
-            }
+            [
+                DateTime::class => [
+                    static function (object $param) use (&$listener1, $event) {
+                        $listener1 = $param === $event;
+                        throw new RuntimeException('test');
+                    },
+                    static function (object $param) use (&$listener2, $event) {
+                        $listener2 = $param === $event;
+                    },
+                ],
+            ]
         );
 
         $this->expectException(RuntimeException::class);
         try {
             $dispatcher->dispatch($event);
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             throw $e;
         } finally {
             self::assertTrue($listener1);
@@ -67,12 +75,16 @@ class SimpleEventDispatcherTest extends TestCase
         $listener1 = false;
         $listener2 = false;
         $dispatcher = $this->prepareDispatcher(
-            static function (object $event) use (&$listener1) {
-                $listener1 = true;
-            },
-            static function (object $event) use (&$listener2) {
-                $listener2 = true;
-            }
+            [
+                StoppableEvent::class => [
+                    static function () use (&$listener1) {
+                        $listener1 = true;
+                    },
+                    static function () use (&$listener2) {
+                        $listener2 = true;
+                    },
+                ],
+            ]
         );
 
         $dispatcher->dispatch($event);
@@ -88,13 +100,17 @@ class SimpleEventDispatcherTest extends TestCase
         $listener1 = false;
         $listener2 = false;
         $dispatcher = $this->prepareDispatcher(
-            static function (object $event) use (&$listener1) {
-                $listener1 = true;
-                $event->setPropagationStopped(true);
-            },
-            static function (object $event) use (&$listener2) {
-                $listener2 = true;
-            }
+            [
+                StoppableEvent::class => [
+                    static function (object $event) use (&$listener1) {
+                        $listener1 = true;
+                        $event->setPropagationStopped(true);
+                    },
+                    static function () use (&$listener2) {
+                        $listener2 = true;
+                    },
+                ],
+            ]
         );
 
         $dispatcher->dispatch($event);
@@ -107,36 +123,36 @@ class SimpleEventDispatcherTest extends TestCase
     public function testIsClassTriggered(): void
     {
         $event = new DateTimeImmutable();
-        $dispatcher = $this->prepareDispatcher();
+        $dispatcher = $this->prepareDispatcher([]);
 
         $dispatcher->dispatch($event);
 
-        $this->assertTrue($dispatcher->isClassTriggered(DateTimeImmutable::class));
-        $this->assertFalse($dispatcher->isClassTriggered(DateTimeInterface::class));
+        self::assertTrue($dispatcher->isClassTriggered(DateTimeImmutable::class));
+        self::assertFalse($dispatcher->isClassTriggered(DateTimeInterface::class));
     }
 
     public function testIsInstanceOfTriggered(): void
     {
         $event = new DateTimeImmutable();
-        $dispatcher = $this->prepareDispatcher();
+        $dispatcher = $this->prepareDispatcher([]);
 
         $dispatcher->dispatch($event);
 
-        $this->assertTrue($dispatcher->isInstanceOfTriggered(DateTimeImmutable::class));
-        $this->assertTrue($dispatcher->isInstanceOfTriggered(DateTimeInterface::class));
-        $this->assertFalse($dispatcher->isInstanceOfTriggered(DateTime::class));
+        self::assertTrue($dispatcher->isInstanceOfTriggered(DateTimeImmutable::class));
+        self::assertTrue($dispatcher->isInstanceOfTriggered(DateTimeInterface::class));
+        self::assertFalse($dispatcher->isInstanceOfTriggered(DateTime::class));
     }
 
     public function testIsObjectTriggered(): void
     {
         $event = new DateTimeImmutable();
         $notEvent = new DateTimeImmutable();
-        $dispatcher = $this->prepareDispatcher();
+        $dispatcher = $this->prepareDispatcher([]);
 
         $dispatcher->dispatch($event);
 
-        $this->assertTrue($dispatcher->isObjectTriggered($event));
-        $this->assertFalse($dispatcher->isObjectTriggered($notEvent));
+        self::assertTrue($dispatcher->isObjectTriggered($event));
+        self::assertFalse($dispatcher->isObjectTriggered($notEvent));
     }
 
     public function testGetEvents(): void
@@ -144,24 +160,57 @@ class SimpleEventDispatcherTest extends TestCase
         $event1 = new DateTimeImmutable();
         $event2 = new DateTimeImmutable();
         $event3 = new DateTimeImmutable();
-        $dispatcher = $this->prepareDispatcher();
+        $dispatcher = $this->prepareDispatcher([]);
 
         $dispatcher->dispatch($event1);
         $dispatcher->dispatch($event2);
         $dispatcher->dispatch($event3);
 
-        $this->assertSame([$event1, $event2, $event3], $dispatcher->getEvents());
+        self::assertSame([$event1, $event2, $event3], $dispatcher->getEvents());
     }
 
     public function testGetEmptyEvents(): void
     {
-        $dispatcher = $this->prepareDispatcher();
+        $dispatcher = $this->prepareDispatcher([]);
 
-        $this->assertSame([], $dispatcher->getEvents());
+        self::assertSame([], $dispatcher->getEvents());
     }
 
-    protected function prepareDispatcher(Closure ...$dispatcher): SimpleEventDispatcher
+    public function testDifferentListeners(): void
     {
-        return new SimpleEventDispatcher(...$dispatcher);
+        $event = new DateTimeImmutable();
+
+        $listener1 = false;
+        $listener2 = false;
+        $listener3 = false;
+        $listeners = [
+            DateTimeImmutable::class => [
+                static function () use (&$listener1) {
+                    $listener1 = true;
+                },
+            ],
+            DateTimeInterface::class => [
+                static function () use (&$listener2) {
+                    $listener2 = true;
+                },
+            ],
+            DateTime::class => [
+                static function () use (&$listener3) {
+                    $listener3 = true;
+                },
+            ],
+        ];
+
+        $this->prepareDispatcher($listeners)->dispatch($event);
+
+        self::assertTrue($listener1);
+        self::assertTrue($listener2);
+        self::assertFalse($listener3);
+    }
+
+
+    protected function prepareDispatcher(array $handlers): SimpleEventDispatcher
+    {
+        return new SimpleEventDispatcher($handlers);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | ❌

In this PR I made `SimpleEventDispatcher` to fit the PSR-14: Each called listener must be type-compatible with the given event. It is too hard to test complicated cases without this condition met.