### PR TITLE
Add Assert helper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     },
     "require": {
         "php": "^7.4|^8.0",
+        "phpunit/phpunit": "^9.5",
         "psr/container": "^1.0|^2.0",
         "psr/event-dispatcher": "^1.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
         "roave/infection-static-analysis-plugin": "^1.7",
         "spatie/phpunit-watcher": "^1.23",
         "vimeo/psalm": "^4.6"

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -15,8 +15,11 @@ final class Assert
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      * @throws ExpectationFailedException
      */
-    public static function assertEqualIgnoringLineEndings(string $expected, string $actual, string $message = ''): void
-    {
+    public static function assertEqualStringsIgnoringLineEndings(
+        string $expected,
+        string $actual,
+        string $message = ''
+    ): void {
         $expected = self::normalizeLineEndings($expected);
         $actual = self::normalizeLineEndings($actual);
 

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -34,7 +34,7 @@ final class Assert
     ): void {
         $needle = self::normalizeLineEndings($needle);
         $haystack = self::normalizeLineEndings($haystack);
-        
+
         PhpUnitAssert::assertStringContainsString($needle, $haystack, $message);
     }
 

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Test\Support;
+
+use PHPUnit\Framework\Assert as PhpUnitAssert;
+use PHPUnit\Framework\ExpectationFailedException;
+
+final class Assert
+{
+    /**
+     * Asserts that two strings equality ignoring line endings.
+     *
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
+     */
+    public static function assertEqualIgnoringLineEndings(string $expected, string $actual, string $message = ''): void
+    {
+        $expected = self::normalizeLineEndings($expected);
+        $actual = self::normalizeLineEndings($actual);
+
+        PhpUnitAssert::assertEquals($expected, $actual, $message);
+    }
+
+    /**
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ExpectationFailedException
+     */
+    public static function assertStringContainsStringIgnoringLineEndings(
+        string $needle,
+        string $haystack,
+        string $message = ''
+    ): void {
+        $needle = self::normalizeLineEndings($needle);
+        $haystack = self::normalizeLineEndings($haystack);
+        
+        PhpUnitAssert::assertStringContainsString($needle, $haystack, $message);
+    }
+
+    private static function normalizeLineEndings(string $value): string
+    {
+        return strtr($value, [
+            "\r\n" => "\n",
+            "\r" => "\n",
+        ]);
+    }
+}

--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -10,7 +10,7 @@ use Yiisoft\Test\Support\Assert;
 
 final class AssertTest extends TestCase
 {
-    public function dataAssertEqualIgnoringLineEndings(): array
+    public function dataAssertEqualStringsIgnoringLineEndings(): array
     {
         return [
             'lf-crlf' => ["a\nb", "a\r\nb"],
@@ -26,14 +26,14 @@ final class AssertTest extends TestCase
     }
 
     /**
-     * @dataProvider dataAssertEqualIgnoringLineEndings
+     * @dataProvider dataAssertEqualStringsIgnoringLineEndings
      */
-    public function testAssertEqualIgnoringLineEndings(string $expected, string $actual): void
+    public function testAssertEqualStringsIgnoringLineEndings(string $expected, string $actual): void
     {
-        Assert::assertEqualIgnoringLineEndings($expected, $actual);
+        Assert::assertEqualStringsIgnoringLineEndings($expected, $actual);
     }
 
-    public function dataNotAssertEqualIgnoringLineEndings(): array
+    public function dataNotAssertEqualStringsIgnoringLineEndings(): array
     {
         return [
             ["a\nb", 'ab'],
@@ -43,12 +43,12 @@ final class AssertTest extends TestCase
     }
 
     /**
-     * @dataProvider dataNotAssertEqualIgnoringLineEndings
+     * @dataProvider dataNotAssertEqualStringsIgnoringLineEndings
      */
-    public function testNotAssertEqualIgnoringLineEndings(string $expected, string $actual): void
+    public function testNotAssertEqualStringsIgnoringLineEndings(string $expected, string $actual): void
     {
         $this->expectException(ExpectationFailedException::class);
-        Assert::assertEqualIgnoringLineEndings($expected, $actual);
+        Assert::assertEqualStringsIgnoringLineEndings($expected, $actual);
     }
 
     public function dataAssertStringContainsStringIgnoringLineEndings(): array

--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Test\Support\Tests;
+
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Test\Support\Assert;
+
+final class AssertTest extends TestCase
+{
+    public function dataAssertEqualIgnoringLineEndings(): array
+    {
+        return [
+            'lf-crlf' => ["a\nb", "a\r\nb"],
+            'cr-crlf' => ["a\rb", "a\r\nb"],
+            'crlf-crlf' => ["a\r\nb", "a\r\nb"],
+            'lf-cr' => ["a\nb", "a\rb"],
+            'cr-cr' => ["a\rb", "a\rb"],
+            'crlf-cr' => ["a\r\nb", "a\rb"],
+            'lf-lf' => ["a\nb", "a\nb"],
+            'cr-lf' => ["a\rb", "a\nb"],
+            'crlf-lf' => ["a\r\nb", "a\nb"],
+        ];
+    }
+
+    /**
+     * @dataProvider dataAssertEqualIgnoringLineEndings
+     */
+    public function testAssertEqualIgnoringLineEndings(string $expected, string $actual): void
+    {
+        Assert::assertEqualIgnoringLineEndings($expected, $actual);
+    }
+
+    public function dataNotAssertEqualIgnoringLineEndings(): array
+    {
+        return [
+            ["a\nb", 'ab'],
+            ["a\rb", 'ab'],
+            ["a\r\nb", 'ab'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataNotAssertEqualIgnoringLineEndings
+     */
+    public function testNotAssertEqualIgnoringLineEndings(string $expected, string $actual): void
+    {
+        $this->expectException(ExpectationFailedException::class);
+        Assert::assertEqualIgnoringLineEndings($expected, $actual);
+    }
+
+    public function dataAssertStringContainsStringIgnoringLineEndings(): array
+    {
+        return [
+            ["b\nc", "b\r\nc"],
+            ["b\nc", "a\r\nb\r\nc\r\nd"],
+        ];
+    }
+
+    /**
+     * @dataProvider dataAssertStringContainsStringIgnoringLineEndings
+     */
+    public function testAssertStringContainsStringIgnoringLineEndings(string $needle, string $haystack): void
+    {
+        Assert::assertStringContainsStringIgnoringLineEndings($needle, $haystack);
+    }
+
+    public function testNotAssertStringContainsStringIgnoringLineEndings(): void
+    {
+        $this->expectException(ExpectationFailedException::class);
+        Assert::assertStringContainsStringIgnoringLineEndings("b\nc", "\r\nc\r\n");
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

Add two methods:
- `Assert::assertEqualStringsIgnoringLineEndings()`
- `Assert::assertStringContainsStringIgnoringLineEndings()`
