### PR TITLE
Add SimpleContainer as 2nd parameter in container factory closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 # Yii Test Support Change Log
 
-
 ## 1.3.1 under development
 
-- no changes in this release.
-
+- Enh #31: Add `SimpleContainer` as 2nd parameter in container factory closure (vjik) 
 
 ## 1.3.0 March 15, 2021
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -53,7 +53,7 @@ use Yiisoft\Test\Support\Container\SimpleContainer;
 
 $container = new SimpleContainer(
     ['foo' => 'Foo'],
-    fn (string $id) => $id === 'bar' ? 'Bar' : 'Not found'
+    fn (string $id, SimpleContainer $container) => $id === 'bar' ? 'Bar' : 'Not found'
 );
 $foo = $container->get('foo'); // Foo
 $foo = $container->get('bar'); // Bar

--- a/docs/ru/README.md
+++ b/docs/ru/README.md
@@ -56,7 +56,7 @@ use Yiisoft\Test\Support\Container\SimpleContainer;
 
 $container = new SimpleContainer(
     ['foo' => 'Foo'],
-    fn (string $id) => $id === 'bar' ? 'Bar' : 'Not found'
+    fn (string $id, SimpleContainer $container) => $id === 'bar' ? 'Bar' : 'Not found'
 );
 $foo = $container->get('foo'); // Foo
 $foo = $container->get('bar'); // Bar

--- a/src/Container/SimpleContainer.php
+++ b/src/Container/SimpleContainer.php
@@ -8,6 +8,7 @@ use Closure;
 use Psr\Container\ContainerInterface;
 use Throwable;
 use Yiisoft\Test\Support\Container\Exception\NotFoundException;
+
 use function array_key_exists;
 
 final class SimpleContainer implements ContainerInterface
@@ -30,7 +31,7 @@ final class SimpleContainer implements ContainerInterface
     public function get($id)
     {
         if (!array_key_exists($id, $this->definitions)) {
-            $this->definitions[$id] = ($this->factory)($id);
+            $this->definitions[$id] = ($this->factory)($id, $this);
         }
         return $this->definitions[$id];
     }

--- a/tests/Container/SimpleContainerTest.php
+++ b/tests/Container/SimpleContainerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Test\Support\Tests\Container;
 
 use Closure;
+use Psr\Container\ContainerInterface;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 
 final class SimpleContainerTest extends BaseContainerTest
@@ -28,6 +29,13 @@ final class SimpleContainerTest extends BaseContainerTest
         $container = $this->createContainer(['foo' => 'foo'], static fn ($id) => 'bar');
 
         $this->assertSame('foo', $container->get('foo'));
+    }
+
+    public function testClosureWithContainerInterface(): void
+    {
+        $container = $this->createContainer([], static fn (string $id, SimpleContainer $container) => $container);
+
+        $this->assertSame($container, $container->get(ContainerInterface::class));
     }
 
     protected function createContainer(array $definitions = [], Closure $closure = null): SimpleContainer


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

For example, this is useful for injector:

```php
new SimpleContainer(
	[],
	static function (string $id, SimpleContainer $container) {
		if ($id === Injector::class) {
			return new Injector($container);
		}
		throw new NotFoundException($id);
	}
)
```